### PR TITLE
Link to the old archive

### DIFF
--- a/app/views/angular/_nav.html.erb
+++ b/app/views/angular/_nav.html.erb
@@ -8,6 +8,7 @@
 		<div><a ng-click="go('/shows', $event)">Shows</a></div>
 		<!-- <div><a ng-click="go('/schedule', $event)">Schedule</a></div> -->
 		<div><a ng-click="go('/about', $event)">About</a></div>
+		<div><a  ng-href="http://archive.bel-air.org/" ng-click="openItem($event)" target="_blank">Archive</a></div>
 	</div>
 
 	<div class="modal-footer">


### PR DESCRIPTION
Trying to work on https://github.com/mikekaminsky/belair/issues/51

The link works, but I'm afraid the archive won't function correctly any more once we change the DNS settings. Namely, this link (and all the others like it):

http://bel-air.org/archive/20160526/djMoniker_20160526.mp3

Will no longer be valid.

Could we use redirects on the new site to fix this?
