### PR TITLE
Slight refactor to AudioPlayer.stream_exists setting

### DIFF
--- a/app/assets/javascripts/controllers/player_controller.js
+++ b/app/assets/javascripts/controllers/player_controller.js
@@ -18,7 +18,7 @@ belAir.controller('PlayerController', ['AudioPlayer', '$scope', function(AudioPl
   }
 
   $scope.streamExists = function streamExists() {
-    return AudioPlayer.stream_exists;
+    return AudioPlayer.streamExists();
   }
 
   $scope.handlePlayerToggle = function handlePlayerToggle(stream) {

--- a/app/assets/javascripts/services/audio_player.js
+++ b/app/assets/javascripts/services/audio_player.js
@@ -1,6 +1,6 @@
 belAir.service('AudioPlayer', ['$http', function AudioPlayerService($http) {
   var self = this;
-  self.stream_exists = true;
+  self.stream_exists = false;
 
   var livestream = {
     file_url: BelAir.livestreamURL,
@@ -55,6 +55,7 @@ belAir.service('AudioPlayer', ['$http', function AudioPlayerService($http) {
 
   this.setSource = function(episode) {
     self.episode = episode;
+    self.stream_exists = episode.file_url == BelAir.livestreamURL;
     player.setSrc(episode.file_url);
   };
 
@@ -71,7 +72,9 @@ belAir.service('AudioPlayer', ['$http', function AudioPlayerService($http) {
     self.play();
   };
 
-
+  this.streamExists = function() {
+    return self.stream_exists;
+  }
 
   this.handlePlayerToggle = function(stream) {
     if (stream){


### PR DESCRIPTION
The new UI element for toggling between the live stream and an archived episode includes an element that displays conditionally based on AudioPlayer.stream_exists. That property was initialized as true and checked in AudioPlayer.onLivestreamError(). This caused the "On Air RN" button to display for a second and then disappear.

I have changed AudioPlayer to initialize stream_exists as false, and set it in AudioPlayer.setSource() instead by checking episode.file_url against BelAir.livestreamURL. I also added a getter for stream_exists.
